### PR TITLE
fixes to deal with the limitations of mongodb, grpc-gatway and bson

### DIFF
--- a/datatrails-common-api/assets/v2/assets/eventresponse.proto
+++ b/datatrails-common-api/assets/v2/assets/eventresponse.proto
@@ -173,11 +173,14 @@ message EventResponse {
     // record. We anticipate at least two proof mechs: merkle_log and
     // verkle_log. We use oneof to avoid repeating the scattering of randomly
     // re-purposed fields we currently have for simple hash vs khipu.
-    oneof proof_details {
-        MerkleLogEntry merklelog_entry = 19 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-            description:
-            "verifiable merkle mmr log entry details"
-            max_length: 1024
-        }];
-    };
+
+
+    // proof details for proof_mechanism MERKLE_LOG
+    MerkleLogEntry merklelog_entry = 19 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+        description:
+        "verifiable merkle mmr log entry details",
+        // see https://github.com/grpc-ecosystem/grpc-gateway/blob/master/protoc-gen-openapiv2/options/openapiv2.proto
+        //  for specific types.
+        type: OBJECT
+    }];
 }

--- a/datatrails-common-api/assets/v2/assets/merklelogentry.proto
+++ b/datatrails-common-api/assets/v2/assets/merklelogentry.proto
@@ -8,12 +8,32 @@ import "google/protobuf/timestamp.proto";
 // MerkeLogCommit provides the log entry details for a single mmr leaf.
 message MerkleLogCommit {
     /* The mmr index */
-    uint64 index = 3;
+    uint64 index = 1;
     /* The mmr *leaf* index */
-    uint64 leaf_index = 4; // TBD: this may be redundant.
+    uint64 leaf_index = 2; // TBD: this may be redundant.
     /* time ordered and strictly unique per tenant. system wide
      * unique with very reasonable operational assumptions. */
-    fixed64 idtimestamp = 5;
+    fixed64 idtimestamp = 3;
+}
+
+message MerkleLogCommitMongoDB {
+
+    // Note that should we ever have more than 2^63  events in a tenant log, the
+    // index and leaf_index fields will not persist to mongo.
+
+    /* The mmr index */
+    uint64 index = 1;
+    /* The mmr *leaf* index */
+    uint64 leaf_index = 2; // TBD: this may be redundant.
+
+    /* time ordered and strictly unique per tenant. system wide
+     * unique with very reasonable operational assumptions.
+     *
+     * EXPRESSED AS A 16 character padded hex string because mongo db does not
+     * support unsigned integers and we need all 64 bits to get a sensible epoch
+     * duration.
+     */
+    string idtimestamp = 3;
 }
 
 // The message sent from forestrie to avid notifying that the corresponding
@@ -42,8 +62,10 @@ message MerkleLogEntry {
     uint32 log_version = 1;
     uint32 log_epoch = 2;
 
-    // Event trust level commited fields
-    MerkleLogCommit commit = 3;
+    // Event trust level commited fields. Note that we have to use a special
+    // message because mongo db does not support unsigned integers. If/when we
+    // move away from that, we can move this ordinal safely into a oneof
+    MerkleLogCommitMongoDB commit = 3;
 
     // TODO: Event trust level confirmed fields
 


### PR DESCRIPTION
fix: oneof doesn't play well with grpc gateway (apparently)

Instead of the (much cleaner) oneof, we will have a single message in the event per proof mech. only one of them will be present in any event

fix: mongo cant store unsigned integers of any size

So we use a different message for storing the proof details for mongo. It encodes the idtimestamp as a fixed lenght hex string. this preserves the sortable and comparible properties.

For now we keep the other unsigned types as they wont use the full range of bits until a single tenant log has 2^63 events in it.

fix: the field ordinals for merkle log messages were benignly 'wrong'. All message fields for merkle log messages start at ordinal 1 now

[AB#8859](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8859)