### PR TITLE
improve deleted field reservation for list events

### DIFF
--- a/datatrails-common-api/assets/v2/assets/listevents.proto
+++ b/datatrails-common-api/assets/v2/assets/listevents.proto
@@ -43,10 +43,12 @@ message ListEventsRequest {
     Principal principal_declared = 6;
     Principal principal_accepted = 7;
 
-    // what was field 8 called?
     reserved 8;
+    reserved "attributes";
 
-    // where are fields 9,10 ?
+    // AFAICT fields 9 and 10 were skipped over when the message was first defined. Reserving
+    // for safety.
+    reserved 9, 10;
 
     // Filtering
     google.protobuf.Timestamp timestamp_accepted_since = 11 [ (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {


### PR DESCRIPTION
I did some digging to find the "missing" name of deleted field 8 in `ListEventsRequest`:

```
// user defined attributes key max_length: 1024 value max_length: 4096
map<string, string> attributes = 8;
```
It seems that fields 9 and 10 were simply omitted when this message was first defined.

re [AB#9754](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/9754)