### PR TITLE
Tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,3 @@ The protos can be included exactly as they are found from a clone of go-datatrai
         DATATRAILS_COMMON_API="../../go-datatrails-common-api"
 
 It is necessary however to run `task apis:bootsrap` after cloning go-datatrails-common
-
-Ignore this comment
-

--- a/datatrails-common-api/assets/v2/assets/service.proto
+++ b/datatrails-common-api/assets/v2/assets/service.proto
@@ -70,12 +70,6 @@ service Assets {
                 }
             }
             responses: {
-                key: "402";
-                value: {
-                    description: "Returned when the user's quota of Assets for the given proof mechanism has been reached."
-                }
-            }
-            responses: {
                 key: "403";
                 value: {
                     description: "Returned when the user is not authorized to list Assets.";


### PR DESCRIPTION
Remove 402 from ListAssets as meaningless

Previous release did not work probaly because of testing the CI pipeline with authentication enabled.

[AB#10228](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/10228)